### PR TITLE
Changed the button to correctly start the tutorial game.

### DIFF
--- a/source/core/src/main/com/deco2800/game/components/mainmenu/MainMenuDisplay.java
+++ b/source/core/src/main/com/deco2800/game/components/mainmenu/MainMenuDisplay.java
@@ -76,7 +76,7 @@ public class MainMenuDisplay extends UIComponent {
                   @Override
                   public void changed(ChangeEvent changeEvent, Actor actor) {
                       logger.debug("Start button clicked");
-                      entity.getEvents().trigger("startTest");
+                      entity.getEvents().trigger("startTutorial");
                   }
               });
 


### PR DESCRIPTION
The third start button will correctly load the tutorial room that has been used to implement test cutscenes. This was the only solution because there was no proper map implemented prior to this. 